### PR TITLE
kbd_nav: disable nav shortcuts when inside a dialog

### DIFF
--- a/modules/kbd_nav/js/kbd_nav.js
+++ b/modules/kbd_nav/js/kbd_nav.js
@@ -27,6 +27,11 @@ $.fn.KbdNavigation = function(options, callback) {
     if ($('#sb-body-inner>img#sb-content').is(':visible')) {
       return false;
     }
+    // ignore shortcuts when inside a jQuery dialog; otherwise it becomes impossible
+    // to navigate the cursor inside an input box
+    if ($('.ui-widget-overlay').is(':visible')) {
+      return true;
+    }
 
     var direction = "ltr";
     if (document.body) {


### PR DESCRIPTION
This small patch disables kbd_nav when a jQuery dialog is open. Without it, the module quickly becomes annoying e.g. when deleting individual tags from an image. Please pull.
