### PR TITLE
Batchtag module improvement

### DIFF
--- a/3.0/modules/batchtag/controllers/batchtag.php
+++ b/3.0/modules/batchtag/controllers/batchtag.php
@@ -25,42 +25,93 @@ class BatchTag_Controller extends Controller {
     access::verify_csrf();
 
     $input = Input::instance();
+    url::redirect(url::abs_site("batchtag/tagitems2?name={$input->post('name')}&item_id={$input->post('item_id')}&tag_subitems={$input->post('tag_subitems')}&csrf={$input->post('csrf')}"));
 
+  }
+  
+  public function tagitems2() {
+    // Tag all non-album items in the current album with the specified tags.
+
+    // Prevent Cross Site Request Forgery
+    access::verify_csrf();
+
+    $input = Input::instance();
+
+    // Variables
+    if (($input->get("batchtag_max") == false) || ($input->get("batchtag_max") == "0")) {
+      $batchtag_max = "50";
+    } else {
+      $batchtag_max = $input->get("batchtag_max");      
+    }
+    if ($input->get("batchtag_items_processed") == false) {
+      $batchtag_items_processed = "0";
+    } else {
+      $batchtag_items_processed = $input->get("batchtag_items_processed");
+    }
+    
     // Figure out if the contents of sub-albums should also be tagged
-    $str_tag_subitems = $input->post("tag_subitems");
+    $str_tag_subitems = $input->get("tag_subitems");
 
     $children = "";
     if ($str_tag_subitems == false) {
       // Generate an array of all non-album items in the current album.
       $children = ORM::factory("item")
-        ->where("parent_id", "=", $input->post("item_id"))
+        ->where("parent_id", "=", $input->get("item_id"))
         ->where("type", "!=", "album")
         ->find_all();
     } else {
       // Generate an array of all non-album items in the current album
       //   and any sub albums.
-      $item = ORM::factory("item", $input->post("item_id"));
+      $item = ORM::factory("item", $input->get("item_id"));
       $children = $item->descendants();
     }
+    
     // Loop through each item in the album and make sure the user has
     //   access to view and edit it.
-    foreach ($children as $child) {
-      if (access::can("view", $child) && access::can("edit", $child) && !$child->is_album()) {
+    $children_count = "0";
+    $tag_count = "0";
 
-        // Assuming the user can view/edit the current item, loop
-        //   through each tag that was submitted and apply it to
-        //   the current item.
-        foreach (explode(",", $input->post("name")) as $tag_name) {
-          $tag_name = trim($tag_name);
-          if ($tag_name) {
-            tag::add($child, $tag_name);
+    //echo Kohana::debug($children);
+
+    echo '<style>.continue { margin: 5em auto; text-align: center; }</style>';
+
+    foreach ($children as $child) {
+      
+      if ($tag_count < $batchtag_max) {
+      
+        if ($children_count >= $batchtag_items_processed) {
+          if (access::can("view", $child) && access::can("edit", $child) && !$child->is_album()) {
+
+            // Assuming the user can view/edit the current item, loop
+            //   through each tag that was submitted and apply it to
+            //   the current item.
+            foreach (explode(",", $input->get("name")) as $tag_name) {
+              $tag_name = trim($tag_name);
+              if ($tag_name) {
+                tag::add($child, $tag_name);
+              }
+              // $tag_count should be inside the foreach loop as it is depending on the number of time tag:add is run
+              $tag_count++;
+            }
           }
-        }
-      }
+          echo '<style>.c' . $children_count . ' { display:none; }</style>' . "\n";
+          $children_count++;
+          $batchtag_max_new = $tag_count;
+          echo '<div class="continue c' . $children_count . '"><a href="' . url::abs_site("batchtag/tagitems2?name={$input->get('name')}&item_id={$input->get('item_id')}&tag_subitems={$input->get('tag_subitems')}&batchtag_items_processed=$children_count&batchtag_max=$batchtag_max_new&csrf={$input->get('csrf')}") . '">Continue</a></div>';
+        } else { $children_count++; }
+        
+      } else { break; }
+
     }
 
-    // Redirect back to the album.
-    $item = ORM::factory("item", $input->post("item_id"));
-    url::redirect(url::abs_site("{$item->type}s/{$item->id}"));
+    if ($tag_count < $batchtag_max) {
+      // Redirect back to the album.
+      $item = ORM::factory("item", $input->get("item_id"));
+      url::redirect(url::abs_site("{$item->type}s/{$item->id}"));
+      //echo url::abs_site("{$item->type}s/{$item->id}");
+    } else {
+      url::redirect(url::abs_site("batchtag/tagitems2?name={$input->get('name')}&item_id={$input->get('item_id')}&tag_subitems={$input->get('tag_subitems')}&batchtag_items_processed=$children_count&batchtag_max=$batchtag_max&csrf={$input->get('csrf')}"));
+      //echo url::abs_site("batchtag/tagitems2?name={$input->get('name')}&item_id={$input->get('item_id')}&tag_subitems={$input->get('tag_subitems')}&batchtag_items_processed=$children_count&batchtag_max=$batchtag_max&csrf={$input->get('csrf')}");
+    }
   }
 }


### PR DESCRIPTION
Batchtag will "stop" if the album is too large. I've modified it to handle large albums. Now, the module will only tag 50 at a time and continue automatically.

If it is still too much, and it "stops", there will also be a "continue" link to allow resuming.

The continue link will also adjust the maximum number of tags at a time (from the default 50) to the current number where batchtag "stops".
