### PR TITLE
Add tag support to captionator contrib module.

### DIFF
--- a/3.0/modules/captionator/controllers/captionator.php
+++ b/3.0/modules/captionator/controllers/captionator.php
@@ -30,6 +30,18 @@ class Captionator_Controller extends Controller {
     $v = new Theme_View("page.html", "collection", "captionator");
     $v->content = new View("captionator_dialog.html");
     $v->content->album = $album;
+    $v->content->enable_tags = module::is_active("tag");
+    if ($v->content->enable_tags) {
+      $v->content->tags = array();
+      foreach ($album->viewable()->children() as $child) {
+        $item = ORM::factory("item", $child->id);
+        $tag_names = array();
+        foreach (tag::item_tags($item) as $tag) {
+          $tag_names[] = $tag->name;
+        }
+        $v->content->tags[$child->id] = implode(", ", $tag_names);
+      }
+    }
     print $v;
   }
 
@@ -42,12 +54,23 @@ class Captionator_Controller extends Controller {
     if (Input::instance()->post("save")) {
       $titles = Input::instance()->post("title");
       $descriptions = Input::instance()->post("description");
+      $tags = Input::instance()->post("tags");
+      $enable_tags = module::is_active("tag");
       foreach (array_keys($titles) as $id) {
         $item = ORM::factory("item", $id);
         if ($item->loaded() && access::can("edit", $item)) {
           $item->title = $titles[$id];
           $item->description = $descriptions[$id];
           $item->save();
+          if ($enable_tags) {
+            tag::clear_all($item);
+            foreach (explode(",", $tags[$id]) as $tag_name) {
+              if ($tag_name) {
+                tag::add($item, trim($tag_name));
+              }
+            }
+            tag::compact();
+          }
         }
       }
       message::success(t("Captions saved"));

--- a/3.0/modules/captionator/views/captionator_dialog.html.php
+++ b/3.0/modules/captionator/views/captionator_dialog.html.php
@@ -1,5 +1,11 @@
 <?php defined("SYSPATH") or die("No direct script access.") ?>
 <div id="g-captionator-dialog">
+  <script type="text/javascript">
+  $('form input[name^=tags]').ready(function() {
+      $('form input[name^=tags]').autocomplete(
+        '/tags/autocomplete', {max: 30, multiple: true, multipleSeparator: ',', cacheLength: 1});
+    });
+  </script>
   <form action="<?= url::site("captionator/save/{$album->id}") ?>" method="post" id="g-captionator-form">
     <?= access::csrf_form_field() ?>
     <fieldset>
@@ -23,6 +29,12 @@
                 <label for="description[<?= $child->id ?>]"> <?= t("Description") ?> </label>
                 <textarea style="height: 5em" name="description[<?= $child->id ?>]"><?= $child->description ?></textarea>
               </li>
+              <? if ($enable_tags): ?>
+              <li>
+                <label for="tags[<?= $child->id ?>]"> <?= t("Tags (comma separated)") ?> </label>
+                <input type="text" name="tags[<?= $child->id ?>]" class="ac_input" autocomplete="off" value="<?= $tags[$child->id] ?>"/>
+              </li>
+              <? endif ?>
             </ul>
           </td>
         </tr>

--- a/3.1/modules/captionator/controllers/captionator.php
+++ b/3.1/modules/captionator/controllers/captionator.php
@@ -30,6 +30,18 @@ class Captionator_Controller extends Controller {
     $v = new Theme_View("page.html", "collection", "captionator");
     $v->content = new View("captionator_dialog.html");
     $v->content->album = $album;
+    $v->content->enable_tags = module::is_active("tag");
+    if ($v->content->enable_tags) {
+      $v->content->tags = array();
+      foreach ($album->viewable()->children() as $child) {
+        $item = ORM::factory("item", $child->id);
+        $tag_names = array();
+        foreach (tag::item_tags($item) as $tag) {
+          $tag_names[] = $tag->name;
+        }
+        $v->content->tags[$child->id] = implode(", ", $tag_names);
+      }
+    }
     print $v;
   }
 
@@ -42,12 +54,23 @@ class Captionator_Controller extends Controller {
     if (Input::instance()->post("save")) {
       $titles = Input::instance()->post("title");
       $descriptions = Input::instance()->post("description");
+      $tags = Input::instance()->post("tags");
+      $enable_tags = module::is_active("tag");
       foreach (array_keys($titles) as $id) {
         $item = ORM::factory("item", $id);
         if ($item->loaded() && access::can("edit", $item)) {
           $item->title = $titles[$id];
           $item->description = $descriptions[$id];
           $item->save();
+          if ($enable_tags) {
+            tag::clear_all($item);
+            foreach (explode(",", $tags[$id]) as $tag_name) {
+              if ($tag_name) {
+                tag::add($item, trim($tag_name));
+              }
+            }
+            tag::compact();
+          }
         }
       }
       message::success(t("Captions saved"));

--- a/3.1/modules/captionator/views/captionator_dialog.html.php
+++ b/3.1/modules/captionator/views/captionator_dialog.html.php
@@ -1,5 +1,11 @@
 <?php defined("SYSPATH") or die("No direct script access.") ?>
 <div id="g-captionator-dialog">
+  <script type="text/javascript">
+  $('form input[name^=tags]').ready(function() {
+      $('form input[name^=tags]').autocomplete(
+        '/tags/autocomplete', {max: 30, multiple: true, multipleSeparator: ',', cacheLength: 1});
+    });
+  </script>
   <form action="<?= url::site("captionator/save/{$album->id}") ?>" method="post" id="g-captionator-form">
     <?= access::csrf_form_field() ?>
     <fieldset>
@@ -23,6 +29,12 @@
                 <label for="description[<?= $child->id ?>]"> <?= t("Description") ?> </label>
                 <textarea style="height: 5em" name="description[<?= $child->id ?>]"><?= $child->description ?></textarea>
               </li>
+              <? if ($enable_tags): ?>
+              <li>
+                <label for="tags[<?= $child->id ?>]"> <?= t("Tags (comma separated)") ?> </label>
+                <input type="text" name="tags[<?= $child->id ?>]" class="ac_input" autocomplete="off" value="<?= $tags[$child->id] ?>"/>
+              </li>
+              <? endif ?>
             </ul>
           </td>
         </tr>


### PR DESCRIPTION
My first piece of 3.x contrib code. I'm sure you'll have suggestions for improvement. I'd like to factor out the comma delimited assembly/disassembly into the tag model perhaps, but wasn't sure if it's worth doing in this change.

Cheers,
-Beckett
