### PR TITLE
Fix empty displayname

### DIFF
--- a/3.0/modules/ldap/libraries/drivers/IdentityProvider/Ldap.php
+++ b/3.0/modules/ldap/libraries/drivers/IdentityProvider/Ldap.php
@@ -232,7 +232,10 @@ class Ldap_User implements User_Definition {
   }
 
   public function display_name() {
-    return $this->ldap_entry["displayname"][0];
+    if (!empty($this->ldap_entry["displayname"][0])) {
+      return $this->ldap_entry["displayname"][0];
+    }
+    return $this->ldap_entry["cn"][0];
   }
 
   public function __get($key) {


### PR DESCRIPTION
When the optional 'displayName' attribute is empty, use 'cn', which is
mandatory and never empty. This prevents empty names being displayed.
