### PR TITLE
strip_exif module: Version 1.

### DIFF
--- a/3.0/modules/strip_exif/controllers/admin_strip_exif.php
+++ b/3.0/modules/strip_exif/controllers/admin_strip_exif.php
@@ -1,0 +1,118 @@
+<?php defined("SYSPATH") or die("No direct script access.") ?><?php
+
+class Admin_Strip_Exif_Controller extends Admin_Controller {
+    public static $defExifTags = "GPSInfo.GPSVersionID GPSInfo.GPSSatellites GPSInfo.GPSStatus GPSInfo.GPSMeasureMode GPSInfo.GPSDOP GPSInfo.GPSMapDatum GPSInfo.GPSLatitudeRef GPSInfo.GPSLatitude GPSInfo.GPSLongitudeRef GPSInfo.GPSLongitude GPSInfo.GPSAltitude GPSInfo.GPSAltitudeRef GPSInfo.GPSImgDirectionRef GPSInfo.GPSImgDirection GPSInfo.GPSDestLatitudeRef GPSInfo.GPSDestLatitude GPSInfo.GPSDestLongitudeRef GPSInfo.GPSDestLongitude GPSInfo.GPSDestBearingRef GPSInfo.GPSDestBearing";
+    public static $defIptcTags = "Application2.LocationName";
+
+    public function verify() {
+        $data = array();
+        $data['success'] = false;
+
+        if (($val = strip_exif::verify_path($_REQUEST['exiv_path'])) > 0) {
+            module::set_var("strip_exif", "exiv_path", $_REQUEST['exiv_path']);
+            $data['success'] = true;
+        } else {
+            $error = "";
+            switch ($val) {
+                case 0: $error = "Empty file path provided"; break;
+                case -1: $error = "File does not exist"; break;
+                case -2: $error = "Path is a directory"; break;
+                default: $error = "Unspecified error";
+            }
+            $data['error'] = $error;
+        }
+
+        echo json_encode($data);
+    }
+
+    public function index() {
+        $form = $this->_get_form();
+
+        if (request::method() == "post") {
+            access::verify_csrf();
+
+            if ($form->validate()) {
+                module::set_var("strip_exif", "exiv_path", $_POST['exiv_path']);
+
+		if ($_POST['exif_tags'] != "") {
+		    module::set_var("strip_exif", "exif_remove", (isset($_POST['exif_remove']) ? $_POST['exif_remove'] : false));
+		    module::set_var("strip_exif", "exif_tags", $_POST['exif_tags']);
+		} else {
+		    module::set_var("strip_exif", "exif_remove", false);
+		    module::set_var("strip_exif", "exif_tags", self::$defExifTags);
+		}
+
+		if ($_POST['iptc_tags'] != "") {
+		    module::set_var("strip_exif", "iptc_remove", (isset($_POST['iptc_remove']) ? $_POST['iptc_remove'] : false));
+		    module::set_var("strip_exif", "iptc_tags", $_POST['iptc_tags']);
+		} else {
+		    module::set_var("strip_exif", "iptc_remove", false);
+		    module::set_var("strip_exif", "iptc_tags", self::$defIptcTags);
+		}
+
+                if (isset($_POST['verbose']))
+                    module::set_var("strip_exif", "verbose", $_POST['verbose']);
+
+                message::success(t("Settings have been saved"));
+                url::redirect("admin/strip_exif");
+            } else {
+                message::error(t("There was a problem with the submitted form. Please check your values and try again."));
+            }
+        }
+
+        print $this->_get_view();
+    }
+
+    private function _get_view($form = null) {
+        $v = new Admin_View("admin.html");
+        $v->page_title = t("Gallery 3 :: Manage Strip EXIF/IPTC Settings");
+
+        $v->content = new View("admin_strip_exif.html");
+        $v->content->form = empty($form) ? $this->_get_form() : $form;
+
+        return $v;
+    }
+
+    private function _get_form() {
+        $form = new Forge("admin/strip_exif", "", "post", array("id" => "g-admin-strip_exif-form"));
+
+        $group = $form->group("system")->label(t("System"));
+
+        $exivPath = strip_exif::whereis("exiv2");
+        $group  ->input("exiv_path")
+                ->id("exiv_path")
+                ->label(t("Path to exiv2 binary:"))
+                ->value(module::get_var("strip_exif", "exiv_path", $exivPath))
+                ->callback("strip_exif::verify_exiv_path")
+                ->error_messages("required", t("You must enter the path to exiv2"))
+                ->error_messages("invalid", t("File does not exist"))
+                ->error_messages("is_dir", t("File is a directory"))
+                ->message("Auto detected exiv2 here: " . $exivPath);
+
+
+        $group = $form->group("tags")->label(t("Tags"));
+
+        $group  ->checkbox("exif_remove")
+                ->label(t("Strip these EXIF tags:"))
+                ->checked(module::get_var("strip_exif", "exif_remove", true) == 1);
+	if (($exifTags = module::get_var("strip_exif", "exif_tags", self::$defExifTags)) == "")
+	    $exifTags = self::$defExifTags;
+        $group  ->input("exif_tags")
+                ->id("exif_tags")
+                ->value($exifTags);
+
+        $group  ->checkbox("iptc_remove")
+                ->label(t("Strip these IPTC tags:"))
+                ->checked(module::get_var("strip_exif", "iptc_remove", true) == 1);
+	if (($iptcTags = module::get_var("strip_exif", "iptc_tags", self::$defIptcTags)) == "")
+	    $iptcTags = self::$defIptcTags;
+        $group  ->input("iptc_tags")
+                ->id("iptc_tags")
+                ->value($iptcTags);
+
+        $form->submit("submit")->value(t("Save"));
+        return $form;
+    }
+}
+
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab:

--- a/3.0/modules/strip_exif/helpers/strip_exif.php
+++ b/3.0/modules/strip_exif/helpers/strip_exif.php
@@ -1,0 +1,99 @@
+<?php defined("SYSPATH") or die("No direct script access.");
+
+class strip_exif_Core {
+    static function run_exiv($base_cmd, $file) {
+        if (module::get_var("strip_exif", "verbose", 0) >= 1)
+            $logfile = VARPATH . "modules/strip_exif/log/strip_exif.log";
+        else
+            $logfile = "/dev/null";
+
+        self::log(1, "Stripping '" . $file . "'");
+
+        $cmd = $base_cmd . " \"" . $file . "\" >> " . $logfile . " 2>&1";
+        self::log(3, "  " . $cmd);
+        exec($cmd);
+    }
+
+    static function strip($item) {
+        if (!($item->is_photo() && $item->mime_type == "image/jpeg"))
+            return;
+
+        $tags = "";
+        if (module::get_var("strip_exif", "exif_remove", false)) {
+            $tags .= "Exif.";
+            $tags .= preg_replace("/[\s,]+/", " Exif.", module::get_var("strip_exif", "exif_tags", "")) . " ";
+        }
+        if (module::get_var("strip_exif", "iptc_remove", false)) {
+            $tags .= "Iptc.";
+            $tags .= preg_replace("/[\s,]+/", " Iptc.", module::get_var("strip_exif", "iptc_tags", "")) . " ";
+        }
+        $tagList = preg_split("/[\s]+/", $tags, -1, PREG_SPLIT_NO_EMPTY);
+
+        $base_cmd = module::get_var("strip_exif", "exiv_path") . " ";
+        self::log(1, "Stripping tags from item id " . $item->id);
+        foreach ($tagList as $tag) {
+            $base_cmd .= "-M\"del " . $tag . "\"" . " ";
+            self::log(2, "  " . $tag);
+        }
+        self::log(2, "Using command:");
+        self::log(2, "  " . $base_cmd);
+
+        foreach(array($item->file_path(), $item->resize_path(), $item->thumb_path()) as $file) {
+            self::run_exiv($base_cmd, $file);
+        }
+
+        $parent = $item->parent();
+        if ($parent->album_cover_item_id == $item->id) {
+            self::run_exiv($base_cmd, $parent->thumb_path());
+        }
+
+        self::log(1, "Successfully stripped tags from item id " . $item->id);
+    }
+
+    static function whereis($app) {
+        $op = @shell_exec("whereis " . $app);
+        if ($op != "") {
+            $op = explode(" ", $op);
+            for ($i = 1; $i < count($op); $i++) {
+                if (file_exists($op[$i]) && !is_dir($op[$i]))
+                    return $op[$i];
+            }
+        }
+        return false;
+    }
+
+    static function verify_path($path) {
+        if ($path == "")
+            return 0;
+        else if (!file_exists($path))
+            return -1;
+        else if (is_dir($path))
+            return -2;
+
+        return 1;
+    }
+
+    static function verify_exiv_path($field) {
+        $v = self::verify_path($field->value);
+        switch ($v) {
+            case 0: $field->add_error("required", 1); break;
+            case -1: $field->add_error("invalid", 1); break;
+            case -2: $field->add_error("is_dir", 1); break;
+        }
+    }
+
+    static function log($verbosity, $item) {
+        if (module::get_var("strip_exif", "verbose", 0) < $verbosity)
+            return;
+
+        if (is_string($item) || is_numeric($item)) {}
+        else
+            $item = print_r($item, true);
+
+        $fh = fopen(VARPATH . "modules/strip_exif/log/strip_exif.log", "a");
+        fwrite($fh, date("Y-m-d H:i:s") . ": " . $item .  "\n");
+        fclose($fh);
+    }
+}
+
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab:

--- a/3.0/modules/strip_exif/helpers/strip_exif_event.php
+++ b/3.0/modules/strip_exif/helpers/strip_exif_event.php
@@ -1,0 +1,22 @@
+<?php defined("SYSPATH") or die("No direct script access.");
+
+class strip_exif_event_Core {
+    static function admin_menu($menu, $theme) {
+        $menu
+            ->get("settings_menu")
+            ->append(Menu::factory("link")
+            ->id("strip_exif_menu")
+            ->label(t("Strip EXIF/IPTC Data"))
+            ->url(url::site("admin/strip_exif")));
+    }
+
+    static function item_created($item) {
+        strip_exif::strip($item);
+    }
+
+    static function item_updated_data_file($item) {
+        strip_exif::strip($item);
+    }
+}
+
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab:

--- a/3.0/modules/strip_exif/helpers/strip_exif_installer.php
+++ b/3.0/modules/strip_exif/helpers/strip_exif_installer.php
@@ -1,0 +1,38 @@
+<?php defined("SYSPATH") or die("No direct script access.");
+
+class strip_exif_installer {
+    private static function getversion() { return 1; }
+    private static function setversion() { module::set_version("strip_exif", self::getversion()); }
+
+    static function install() {
+        self::setversion();
+
+        @mkdir(VARPATH . "modules/strip_exif");
+        @mkdir(VARPATH . "modules/strip_exif/log");
+    }
+
+    static function upgrade($version) {
+        if ($version < self::getversion())
+            self::setversion();
+    }
+
+    static function can_activate() {
+        $messages = array();
+        if (!function_exists("exec")) {
+            $messages["warn"][] = t("exec() is required to auto-detect the exiv2 binary. You must specify the path to the exiv2 binary manually.");
+        }
+        return $messages;
+    }
+
+    static function activate() {
+    }
+
+    static function deactivate() {
+    }
+
+    static function uninstall() {
+        dir::unlink(VARPATH . "modules/strip_exif");
+    }
+}
+
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab:

--- a/3.0/modules/strip_exif/module.info
+++ b/3.0/modules/strip_exif/module.info
@@ -1,0 +1,7 @@
+name = "Strip EXIF Data"
+description = "Strip EXIF/IPTC data from uploaded photos."
+version = 1
+author_name = "jingai"
+author_url = ""
+info_url = "http://codex.gallery2.org/Gallery3:Modules:strip_exif"
+discuss_url = "http://gallery.menalto.com/forum_module_strip_exif"

--- a/3.0/modules/strip_exif/views/admin_strip_exif.html.php
+++ b/3.0/modules/strip_exif/views/admin_strip_exif.html.php
@@ -1,0 +1,11 @@
+<?php defined("SYSPATH") or die("No direct script access.") ?>	
+
+<div id="g-admin-code-block">
+    <h2><?= t("Strip EXIF/IPTC Tags Settings") ?></h2>
+
+    <p><?= t("Strip EXIF and/or IPTC metadata in uploaded images.  By default, strip out location data."); ?></p>
+
+    <div class="g-block-content">
+        <?php echo $form; ?>
+    </div>
+</div>


### PR DESCRIPTION
Module to strip specified EXIF and IPTC tags from uploaded photos.
By default, set up to strip location data (but not enabled by default).
