### PR TITLE
Enabling the GuessContentType plugin is essential for webdav clients bein

### DIFF
--- a/3.0/modules/webdav/controllers/webdav.php
+++ b/3.0/modules/webdav/controllers/webdav.php
@@ -34,6 +34,7 @@ class WebDAV_Controller extends Controller {
     $server->setBaseUri(url::site("webdav/gallery"));
     // $server->addPlugin($lock);
     $server->addPlugin($filter);
+    $server->addPlugin(new Sabre_DAV_Browser_GuessContentType());
 
     if ($this->_authenticate()) {
       $server->exec();


### PR DESCRIPTION
Enabling the GuessContentType plugin is essential for webdav clients being about to present image previews.  mime type will now be sent back in the response.  

http://code.google.com/p/sabredav/wiki/GuessContentType
