### PR TITLE
Update 3.0/modules/albumtree/views/albumtree_block_dtree.html.php

### DIFF
--- a/3.0/modules/albumtree/views/albumtree_block_dtree.html.php
+++ b/3.0/modules/albumtree/views/albumtree_block_dtree.html.php
@@ -398,7 +398,7 @@ albumTree.config.cookieDomain = '';
 <?
 function addtree($album){
 ?>
-albumTree.add(<?= $album->id -1 ?>, <?= $album->parent_id -1 ?>, "<?= $album->title ?>", pf+'<?= $album->relative_url() ?>');
+albumTree.add(<?= $album->id -1 ?>, <?= $album->parent_id -1 ?>, "<?= html::clean($album->title) ?>", pf+'<?= $album->relative_url() ?>');
 <?
   foreach ($album->viewable()->children(null, null, array(array("type", "=", "album"))) as $child){
     addtree($child);


### PR DESCRIPTION
If item has a quote in the title it dies.  Use "<?= html::clean($album->title) ?>"
