### PR TITLE
Don't block all keyboard usage

### DIFF
--- a/3.0/modules/arrow_nav/js/arrow_nav.js
+++ b/3.0/modules/arrow_nav/js/arrow_nav.js
@@ -11,7 +11,6 @@ $(document).keydown(function(e) {
   
   if(url != undefined) {
       window.location = url;
+      return false;
   }
-
-  return false;
 });


### PR DESCRIPTION
Had return false for all keydown events, preventing the up and down arrow keys from being used to scroll the page, among other things.
