### PR TITLE
Use escapeshellarg() in jhead module to quote new file name

### DIFF
--- a/3.0/modules/jhead/helpers/jhead_event.php
+++ b/3.0/modules/jhead/helpers/jhead_event.php
@@ -39,7 +39,7 @@ class jhead_event_Core {
     }
 
     // Invoke jhead
-    if ($error = exec(escapeshellcmd($binary).' -q -autorot '.$item->file_path())) {
+    if ($error = exec(escapeshellcmd($binary).' -q -autorot '.escapeshellarg($item->file_path()))) {
       // @todo throw an exception ?
       Kohana::log('error', 'Error during execution of jhead');
     }


### PR DESCRIPTION
The jhead module calls the 'jhead' program and passes the newly-created file as an argument, but this file isn't quoted properly.  The command fails if the file name has spaces in it.  Calling escapeshellarg() on the file name seems to be one way to fix this problem.
