### PR TITLE
Fix issue with new user not being assigned to the selected default group

### DIFF
--- a/3.0/modules/register/helpers/register.php
+++ b/3.0/modules/register/helpers/register.php
@@ -108,6 +108,15 @@ class register_Core {
     $new_user->guest = false;
     $new_user->save();
 
+    $group_id = module::get_var("registration", "default_group");
+    if ($group_id != null) {
+        $default_group = group::lookup($group_id);
+        if ($default_group != null) {
+            $default_group->add($new_user);
+            $default_group->save();
+        }
+    }
+
     $user->hash =  md5(uniqid(mt_rand(), true));
     $user->state = 2;
     $user->save();


### PR DESCRIPTION
When creating the new user the default group was never even looked up. Just fixed this so after the user is created they are added to the selected default group if it exists.
