### PR TITLE
Replace http:// links with protocol relative links.

### DIFF
--- a/3.0/modules/exif_gps/views/exif_gps_dynamic_sidebar.html.php
+++ b/3.0/modules/exif_gps/views/exif_gps_dynamic_sidebar.html.php
@@ -1,5 +1,5 @@
 <?php defined("SYSPATH") or die("No direct script access.") ?>
-<script type="text/javascript" src="http://www.google.com/jsapi"></script>
+<script type="text/javascript" src="//www.google.com/jsapi"></script>
 <script type="text/javascript">
 <?
   if (module::get_var("exif_gps", "googlemap_api_key", "") != "") {

--- a/3.0/modules/exif_gps/views/exif_gps_map.html.php
+++ b/3.0/modules/exif_gps/views/exif_gps_map.html.php
@@ -1,5 +1,5 @@
 <?php defined("SYSPATH") or die("No direct script access.") ?>
-<script type="text/javascript" src="http://www.google.com/jsapi"></script>
+<script type="text/javascript" src="//www.google.com/jsapi"></script>
 <script type="text/javascript">
 <?
   if (module::get_var("exif_gps", "googlemap_api_key", "") != "") {

--- a/3.0/modules/exif_gps/views/exif_gps_static_sidebar.html.php
+++ b/3.0/modules/exif_gps/views/exif_gps_static_sidebar.html.php
@@ -5,4 +5,4 @@
     $map_api_key = "&key=" . module::get_var("exif_gps", "googlemap_api_key");
   }
 ?>
-<img src="http://maps.google.com/maps/api/staticmap?center=<?=$latitude; ?>,<?=$longitude; ?>&zoom=<?= module::get_var("exif_gps", "sidebar_zoom"); ?>&size=205x214&maptype=<?=$sidebar_map_type ?>&markers=color:red|color:red|<?=$latitude; ?>,<?=$longitude; ?><?= $map_api_key; ?>&sensor=false">
+<img src="//maps.google.com/maps/api/staticmap?center=<?=$latitude; ?>,<?=$longitude; ?>&zoom=<?= module::get_var("exif_gps", "sidebar_zoom"); ?>&size=205x214&maptype=<?=$sidebar_map_type ?>&markers=color:red|color:red|<?=$latitude; ?>,<?=$longitude; ?><?= $map_api_key; ?>&sensor=false">

--- a/3.0/modules/exif_gps/views/user_profile_exif_gps.html.php
+++ b/3.0/modules/exif_gps/views/user_profile_exif_gps.html.php
@@ -1,5 +1,5 @@
 <?php defined("SYSPATH") or die("No direct script access.") ?>
-<script type="text/javascript" src="http://www.google.com/jsapi"></script>
+<script type="text/javascript" src="//www.google.com/jsapi"></script>
 <script type="text/javascript">
 <?
   if (module::get_var("exif_gps", "googlemap_api_key", "") != "") {


### PR DESCRIPTION
Without this, if the parent page is accessed via https, many browsers
will refuse to run the insecure JavaScript
