### PR TITLE
Updated tagfaces module - drawfaces view

### DIFF
--- a/3.0/modules/tagfaces/views/drawfaces.html.php
+++ b/3.0/modules/tagfaces/views/drawfaces.html.php
@@ -44,7 +44,7 @@
   // Remember to invoke within jQuery(window).load(...)
   // If you don't, Jcrop may not initialize properly
   jQuery(document).ready(function(){
-    jQuery('#g-photo-id-<?=$item->id ?>').Jcrop({
+    jQuery('#g-item-id-<?=$item->id ?>').Jcrop({
       onChange: showCoords,
       onSelect: showCoords
     });

--- a/3.0/modules/tagfaces/views/drawfaces_highlight_block.html.php
+++ b/3.0/modules/tagfaces/views/drawfaces_highlight_block.html.php
@@ -30,14 +30,14 @@
 <script type="text/JavaScript">
   function setfacemap() {
 	// Insert the usemap element into the resize photo's image tag.
-    var photoimg = document.getElementById('g-photo-id-<?=$item->id ?>');
+    var photoimg = document.getElementById('g-item-id-<?=$item->id ?>');
     photoimg.useMap = '#faces';
   }
 
   function highlightbox(x1, y1, x2, y2, str_title, str_description, str_url) {
     var divtext = document.getElementById('divtagtext');
-    var photodiv = document.getElementById('g-photo');
-    var photoimg = document.getElementById('<?="g-photo-id-{$item->id}"?>');
+    var photodiv = document.getElementById('g-item');
+    var photoimg = document.getElementById('<?="g-item-id-{$item->id}"?>');
     var divface = document.getElementById('divsquare');
 
     divface.style.display = 'block';


### PR DESCRIPTION
Upon using the tagfaces module I noticed that when hovering over where the tag was didn't work. I later found that the JavaScript code was trying to get the `g-photo-id-` html element which didn't actually exist. It has now been renamed to `g-item-id-`.

After changing the views that contain `g-photo-id`, hovering over the tag works properly.
