### PR TITLE
ecard module 

### DIFF
--- a/3.0/modules/ecard/controllers/ecard.php
+++ b/3.0/modules/ecard/controllers/ecard.php
@@ -101,9 +101,10 @@ class Ecard_Controller extends Controller {
   }  
   private static function _notify($to, $from, $subject, $item, $text, $headers, $bcc, $cc) {
       $sendmail = Sendmail::factory();
-	  $sendmail
+      $sendmail
         ->to($to)
-		->from($from)
+	->from($from)
+	->reply_to($from)
         ->subject($subject);
 	  if(isset($bcc)) {
 	    $sendmail->header("bcc",$bcc);


### PR DESCRIPTION
Allow the ecard mail to have a reply-to 
This allows the recipient to use their email to reply to the person that sent it not the webserver/webmaster/default server setting. 
