### PR TITLE
Incorporating dup_fix patch from pylibgal3

### DIFF
--- a/3.0/client/Python/pylibgal3/libg3/G3Items.py
+++ b/3.0/client/Python/pylibgal3/libg3/G3Items.py
@@ -52,6 +52,14 @@ class BaseRemote(object):
             pass
         return self.name
 
+    def __repr__(self):
+        try:
+            return '%s : %s : %s' % (self.__dict__.get('id') , 
+                self.__dict__.get('type') , self.__dict__.get('name'))
+        except:
+            pass
+        return type(self)
+
     def __getattr__(self , name):
         """
         A bit of magic to make the retrieval of member objects lazy

--- a/3.0/client/Python/pylibgal3/libg3/Gallery3.py
+++ b/3.0/client/Python/pylibgal3/libg3/Gallery3.py
@@ -164,7 +164,8 @@ class Gallery3(object):
         newObjUrl = self._getUrlFromResp(resp)
         item = getItemFromResp(self.getRespFromUrl(newObjUrl) , self , parent)
         parent._members.append(newObjUrl)
-        parent.members.append(item)
+        # This appears to cause a race 
+        #parent.members.append(item)
         return item
 
     def addImage(self , parent , image , title='' , description='' , name=''):
@@ -213,7 +214,7 @@ class Gallery3(object):
         newObjUrl = self._getUrlFromResp(resp)
         item = getItemFromResp(self.getRespFromUrl(newObjUrl) , self , parent)
         parent._members.append(newObjUrl)
-        parent.members.append(item)
+        #parent.members.append(item)
         return item
 
     def addMovie(self , parent , movie , title='' , description='' , name=''):


### PR DESCRIPTION
This fixes a bug with duplicate items being returned when creating a new album.
