### PR TITLE
Enabling ssl for adsense module

### DIFF
--- a/3.0/modules/adsense/helpers/adsense_theme.php
+++ b/3.0/modules/adsense/helpers/adsense_theme.php
@@ -29,7 +29,7 @@ class adsense_theme {
 		$google_code = '
 		<script type="text/javascript">' . $code . '</script>
 		<script type="text/javascript"
-			src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
+			src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 		</script>';
 
 		return $google_code;
@@ -45,7 +45,7 @@ class adsense_theme {
 		$google_code = '
 		<script type="text/javascript">' . $code . '</script>
 		<script type="text/javascript"
-			src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
+			src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 		</script>';
 
 		return $google_code;

--- a/3.0/modules/adsense/views/adsense_block.html.php
+++ b/3.0/modules/adsense/views/adsense_block.html.php
@@ -8,7 +8,7 @@ if(module::get_var("adsense","location") == "sidebar") {
 	$google_code = '
 	<script type="text/javascript">' . $code . '</script>
 	<script type="text/javascript"
-		src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
+		src="//pagead2.googlesyndication.com/pagead/show_ads.js">
 	</script>';
 	
 	echo $google_code;


### PR DESCRIPTION
If one's Gallery 3 installation is running over `https` the existing adsense module triggers blocked mixed content errors because it fetches the adsense javascript over `http`

https://developer.mozilla.org/en-US/docs/Security/MixedContent

Google supports adsense over `https` as described here

https://support.google.com/adsense/answer/10528?hl=en

This pull request implements this small change