### PR TITLE
[html5_uploader] Fixed input used for upload

### DIFF
--- a/3.0/modules/html5_uploader/controllers/uploader.php
+++ b/3.0/modules/html5_uploader/controllers/uploader.php
@@ -112,7 +112,7 @@ class Uploader_Controller extends Controller {
     $form = new Forge("uploader/add/{$album->id}", "", "post", array("id" => "g-add-photos-form"));
     $group = $form->group("add_photos")
       ->label(t("Add photos to %album_title", array("album_title" => html::purify($album->title))));
-    $group->input("files[]")->type("file")->multiple();
+    $group->upload("files[]")->multiple();
 
     $form->input("FOO")->type("hidden")->label(sprintf("You may upload several files at once. Uploading pictures may take some time - please be patient. Max. upload size of all pictures: %.0f MB.", ini_get("upload_max_filesize")));
 


### PR DESCRIPTION
`input()->type('file')` doesn't make Forge add the `enctype="multipart/form-data"` attribute required to transfer files through a web form. With `upload()` it works ;)